### PR TITLE
Remove tagline from chat header

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -345,9 +345,6 @@ const Index = () => {
                 <h1 className="text-3xl font-serif font-semibold tracking-tight text-foreground sm:text-4xl">
                   Culinary Advisor
                 </h1>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Tailored culinary counsel crafted for your kitchen.
-                </p>
               </div>
             </div>
             <div className="flex items-center gap-3 sm:gap-4">


### PR DESCRIPTION
## Summary
- remove the tagline paragraph beneath the Culinary Advisor logo on the chat page header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df38da1f6883219de4a0e81966c1bb