### PR TITLE
Refine chat page layout

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -330,11 +330,15 @@ const Index = () => {
   };
 
   return (
-    <div className="min-h-screen bg-muted/30">
-      <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col px-4 py-6 sm:px-6 sm:py-10 lg:px-8">
-        <div className="flex w-full min-h-[calc(100vh-3rem)] flex-1 flex-col rounded-3xl border border-border bg-card shadow-refined sm:min-h-[calc(100vh-5rem)]">
+    <div className="relative min-h-screen bg-background">
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute left-1/2 top-[-5rem] h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-primary/10 blur-3xl" />
+        <div className="absolute bottom-[-8rem] right-[-6rem] h-[24rem] w-[24rem] rounded-full bg-muted/40 blur-3xl" />
+      </div>
+      <div className="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 pb-8 pt-20 sm:px-6 sm:pb-12 sm:pt-24 lg:px-8">
+        <div className="flex flex-1 flex-col overflow-hidden rounded-3xl border border-border/60 bg-card/90 shadow-refined backdrop-blur-xl">
           {/* Header */}
-          <header className="flex items-start justify-between gap-6 border-b border-border px-6 py-8">
+          <header className="flex flex-col gap-6 border-b border-border/80 px-6 py-8 sm:flex-row sm:items-center sm:justify-between sm:gap-8">
             <div className="flex items-center gap-4">
               <img
                 src={logoLight}
@@ -347,7 +351,7 @@ const Index = () => {
                 </h1>
               </div>
             </div>
-            <div className="flex items-center gap-3 sm:gap-4">
+            <div className="flex flex-wrap items-center gap-3 sm:flex-nowrap sm:gap-4">
               <Button
                 onClick={() => setShowProfileSheet(true)}
                 variant="ghost"
@@ -391,13 +395,13 @@ const Index = () => {
             {/* Messages Area */}
             <div
               ref={scrollAreaRef}
-              className="flex-1 overflow-y-auto px-6 py-8"
+              className="flex-1 overflow-y-auto px-6 py-8 sm:px-8"
             >
               <div className="space-y-6">
                 {messages.map((message) => (
                   message.eventType === "status" ? (
                     <div key={message.id} className="flex justify-center">
-                      <div className="rounded-full bg-muted px-5 py-2 text-sm text-muted-foreground shadow-refined animate-fade-in">
+                      <div className="animate-fade-in rounded-full bg-muted px-5 py-2 text-sm text-muted-foreground shadow-refined">
                         {message.content}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- replace the Vite chat page container with the refined layout from the resolved conflict, including backdrop overlays and updated spacing
- ensure ChatBubble, the scroll area, and the footer input retain their existing props and handlers after the markup swap

## Testing
- npm run lint *(fails: pre-existing lint errors around explicit `any` types and forbidden require imports)*

------
https://chatgpt.com/codex/tasks/task_e_68df40baf9a4832196899d65fe468fd0